### PR TITLE
Maintenance to build on latest nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-24
           override: true
-          components: rustfmt, clippy, rust-src, llvm-tools-preview
+          components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
 
       - name: Install Cargo Make
@@ -44,7 +44,7 @@ jobs:
           cat Cargo.toml
 
       - name: Compile
-        run: cargo make pi3 --profile pipeline
+        run: cargo make build --profile pipeline
 
   publish_dry:
     name: Run Cargo Publish Dry-Run
@@ -62,9 +62,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-24
           override: true
-          components: rustfmt, clippy, rust-src, llvm-tools-preview
+          components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
 
       - name: Install Cargo Make
@@ -152,9 +152,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-24
           override: true
-          components: rustfmt, clippy, rust-src, llvm-tools-preview
+          components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
 
       - name: Install Cargo Make
@@ -174,5 +174,7 @@ jobs:
           # and the README.md
           sed -i -e 's/||VERSION||/'$CRATE_VERSION'/g' README.md
         
-      - name: Publish-Dry-Run
-        run: cargo make publish --env CRATES_TOKEN=${{ secrets.CRATES_TOKEN }} --profile pipeline
+      - name: Publish
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        run: cargo make -t publish --profile pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## :apple: v0.1.6
+
+Update the crate to compile with latest Rust nightly and Rust edition 2021
+
+- ### :wrench: Maintenance
+
+  - update `Cargo.toml` to use edition 2021
+  - remove `asm` feature flag is it is stabelized now
+  - update dependencies
+
 ## :lemon: v0.1.5
 
 Update the implementation to work with the current Rust version (1.56.0-nightly)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ruspiro-arch-aarch64"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "ruspiro-register",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-arch-aarch64"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.1.5" # remember to update html_root_url in lib.rs
+version = "0.1.6" # remember to update html_root_url in lib.rs
 description = """
 This crate provides access to Aarch64 system registers as well as specific usefull aarch64 assembly instructions
 """
@@ -11,7 +11,7 @@ repository = "https://github.com/RusPiRo/ruspiro-arch-aarch64/tree/v||VERSION||"
 documentation = "https://docs.rs/ruspiro-arch-aarch64/||VERSION||"
 categories = ["no-std", "embedded"]
 keywords = ["ruspiro", "aarch64", "register"]
-edition = "2018"
+edition = "2021"
 exclude = ["Makefile.toml", ".cargo/config.toml"]
 
 [badges]
@@ -19,15 +19,12 @@ maintenance = { status = "actively-developed" }
 
 [lib]
 
-[build-dependencies]
-# uncomment this if a build.rs script should be run as part of the build process
-# cc = "1.0"
-
 [dependencies]
-ruspiro-register = "0.5"
+ruspiro-register = "~0.5.4"
 
-[features]
-ruspiro_pi3 = [ ]
+[package.metadata.docs.rs]
+default-target = "aarch64-unknown-linux-gnu"
+features = []
 
 [patch.crates-io]
 ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "development" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,37 +18,28 @@ RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53"
 
 [tasks.build]
 command = "cargo"
-args = ["build", "--release", "--features", "${FEATURES}"]
-
-[tasks.pi3]
-env = { FEATURES = "" }
-run_task = "build"
+args = ["build", "--release"]
 
 [tasks.clippy]
-env = { FEATURES = "" }
 command = "cargo"
-args = ["clippy", "--features", "${FEATURES}"]
+args = ["clippy"]
 
 [tasks.doc]
-env = { FEATURES = "" }
 command = "cargo"
-args = ["doc", "--target", "aarch64-unknown-linux-gnu", "--open", "--features", "${FEATURES}"]
+args = ["doc", "--target", "aarch64-unknown-linux-gnu", "--open"]
 
 [tasks.doctest]
-env = { FEATURES = "" }
 command = "cargo"
-args = ["test", "--doc", "--features", "${FEATURES}"]
+args = ["test", "--doc"]
 
 [tasks.clean]
 command = "cargo"
 args = ["clean"]
 
 [tasks.publish_dry]
-env = { FEATURES = "" }
 command = "cargo"
-args = ["publish", "--dry-run", "--features", "${FEATURES}"]
+args = ["publish", "--dry-run"]
 
 [tasks.publish]
-env = { FEATURES = "" }
 command = "cargo"
-args = ["publish", "--token", "${CRATES_TOKEN}", "--allow-dirty", "--features", "${FEATURES}"]
+args = ["publish", "--token", "${CRATES_TOKEN}", "--allow-dirty"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2021-12-24"
+components = [ "rustfmt", "clippy", "rust-src", "llvm-tools-preview" ]
+profile = "minimal"

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -9,6 +9,7 @@
 //!
 //! Functions to emit specific assembly instructions
 //!
+use core::arch::asm;
 
 /// assembly NOP instruction
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,7 @@
  **********************************************************************************************************************/
 #![doc(html_root_url = "https://docs.rs/ruspiro-arch-aarch64/||VERSION||")]
 // we require to run with 'std' in unit tests and doc tests to have an allocator in place
-//#![cfg_attr(not(any(test, doctest)), no_std)]
 #![no_std]
-#![feature(asm)]
 
 //! # RusPiRo Aarch64 specific API
 //!

--- a/src/register/macros.rs
+++ b/src/register/macros.rs
@@ -115,7 +115,7 @@ macro_rules! define_aarch64_register {
         pub fn get() -> $t {
             let raw_value: $t;
             unsafe {
-                asm!(
+                core::arch::asm!(
                     concat!("mrs {0:x}, ", stringify!($name)),
                     out(reg) raw_value
                 )
@@ -128,7 +128,7 @@ macro_rules! define_aarch64_register {
         #[allow(dead_code)]
         pub fn set(raw_value: $t) {
             unsafe {
-                asm!(
+                core::arch::asm!(
                     concat!("msr ", stringify!($name) , ", {0:x} "),
                     in(reg) raw_value
                 )


### PR DESCRIPTION
- update to compile on latest nightly and Rust edition 2021
- update dependencies
- remove `asm` feature flag as it is stabilized now